### PR TITLE
Add a link to github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ To play the game:
 ====
 
 clone this repo and run `open index.html`
+[Demo](https://tam-borine.github.io/bowling-challenge/)
 
 
 Bowling Challenge


### PR DESCRIPTION
 will be visible when enabling it in repository settings on github.com
The repository is all set up for it- has an index.html file at root. Github is nice and can host static pages for us, like here:
https://meclav.github.io/bowling-challenge/

You could enable it in settings and get a shareable link with your project.
